### PR TITLE
Add X-Pages header into GetMarketsRegionIdOrders response

### DIFF
--- a/latest/go/api_market.go
+++ b/latest/go/api_market.go
@@ -708,6 +708,7 @@ func GetMarketsRegionIdOrders(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+	w.Header().Set("X-Pages", "1")
 
 	w.Write([]byte(j))
 }


### PR DESCRIPTION
`X-Pages` response header was missing to mimic ESI API. As the mock returns only 1 order, it's safe to return `1` for the `X-Pages` header.